### PR TITLE
Set Search Field Active

### DIFF
--- a/biblewidget.cpp
+++ b/biblewidget.cpp
@@ -566,3 +566,9 @@ bool BibleWidget::isVerseSelected()
     else
         return false;
 }
+
+void BibleWidget::setSearchActive()
+{
+    ui->lineEditBook->setFocus();
+    ui->lineEditBook->selectAll();
+}

--- a/biblewidget.hpp
+++ b/biblewidget.hpp
@@ -60,6 +60,7 @@ public slots:
     void clearHistory();
     void setSelectedHistory(BibleHistory &b);
     bool isVerseSelected();
+    void setSearchActive();
 
 protected:
     virtual void changeEvent(QEvent *e);

--- a/softprojector.cpp
+++ b/softprojector.cpp
@@ -433,9 +433,15 @@ void SoftProjector::keyPressEvent(QKeyEvent *event)
     // Will get called when a key is pressed
     int key = event->key();
     if(key == Qt::Key_F6)
+    {
         ui->projectTab->setCurrentWidget(bibleWidget);
+        bibleWidget->setSearchActive();
+    }
     else if(key == Qt::Key_F7)
+    {
         ui->projectTab->setCurrentWidget(songWidget);
+        songWidget->setSearchActive();
+    }
     else if(key == Qt::Key_F8)
         ui->projectTab->setCurrentWidget(announceWidget);
     else if(key == Qt::Key_Left)

--- a/songwidget.cpp
+++ b/songwidget.cpp
@@ -618,3 +618,9 @@ void SongWidget::on_pushButtonClearResults_clicked()
     sendToPreview(s);
     updateButtonStates();
 }
+
+void SongWidget::setSearchActive()
+{
+    ui->lineEditSearch->setFocus();
+    ui->lineEditSearch->selectAll();
+}

--- a/songwidget.hpp
+++ b/songwidget.hpp
@@ -52,6 +52,7 @@ public slots:
     void sendToPreviewFromSchedule(Song &song);
     void sendToProjector(Song song, int row);
     void songsViewRowChanged(const QModelIndex &current, const QModelIndex &previous);
+    void setSearchActive();
 
 protected:
     virtual void changeEvent(QEvent *e);


### PR DESCRIPTION
I modified the app slightly so that when you press the F6 shortcut, the Bible Book search field gets set as active and anything in that field gets selected. Same for the Song Title field in the Song widget when F7 is pressed. This change helps us pull up what we need during a service much faster. 
Figured others might find this useful.  
