### PR TITLE
Auto sort by song number

### DIFF
--- a/songwidget.cpp
+++ b/songwidget.cpp
@@ -218,6 +218,9 @@ void SongWidget::on_songbook_menu_currentIndexChanged(int index)
 
     updateButtonStates();
 
+    // Sort by song number at initial load, and with songbook change
+    ui->songs_view->sortByColumn(1,Qt::AscendingOrder);
+
     songs_model->emitLayoutChanged(); // forces the view to redraw
 }
 
@@ -229,7 +232,9 @@ void SongWidget::on_song_num_spinbox_valueChanged(int value)
         isSpinboxEditing = true;
         ui->lineEditSearch->clear();
         on_lineEditSearch_textEdited("");
-        ui->songs_view->sortByColumn(0,Qt::AscendingOrder);
+
+        // Sort by song number
+        ui->songs_view->sortByColumn(1,Qt::AscendingOrder);
     }
 
     //int max_num = 0;
@@ -288,6 +293,9 @@ void SongWidget::on_lineEditSearch_textEdited(QString text)
     // If no full-text search is in progress, then filter
     if(!ui->pushButtonClearResults->isVisible())
     {
+        // Sort by song number
+        ui->songs_view->sortByColumn(1,Qt::AscendingOrder);
+
         // These two options are mutually exclusive:
         bool match_beginning = (ui->comboBoxFilterType->currentIndex() == 1);
         bool exact_match = (ui->comboBoxFilterType->currentIndex() == 2);

--- a/songwidget.cpp
+++ b/songwidget.cpp
@@ -293,8 +293,18 @@ void SongWidget::on_lineEditSearch_textEdited(QString text)
     // If no full-text search is in progress, then filter
     if(!ui->pushButtonClearResults->isVisible())
     {
-        // Sort by song number
+
+        // If search test is numeric, sort by the number, else sort by title
+        bool ok;
+        text.toInt(&ok);
+        if(ok)
+        {
         ui->songs_view->sortByColumn(1,Qt::AscendingOrder);
+        }
+        else
+        {
+        ui->songs_view->sortByColumn(2,Qt::AscendingOrder);
+        }
 
         // These two options are mutually exclusive:
         bool match_beginning = (ui->comboBoxFilterType->currentIndex() == 1);


### PR DESCRIPTION
Songs will sort by song number at initial load, with songbook change, and during searches (if the table view is not sorted by number already.)