### PR TITLE
Bible improvements

### DIFF
--- a/biblewidget.cpp
+++ b/biblewidget.cpp
@@ -253,6 +253,8 @@ void BibleWidget::on_lineEditBook_textChanged(QString text)
             // while the rest of the filter must be the beginning of the second book word.
             QString num_str(text.at(0));
             QString name_str = text.remove(0, 1);
+            // Allow for space inbetween num_str and name_str e.g. "1 Peter"
+            name_str = name_str.trimmed();
             for(int i=0; i<all_books.count(); i++)
             {
                 QString book = all_books.at(i);
@@ -439,6 +441,8 @@ void BibleWidget::addToHistory()
     BibleHistory b = getCurrentVerse();
     history_items.append(b);
     ui->history_listWidget->addItem(b.captionLong);
+    // Scroll to latest history item
+    ui->history_listWidget->scrollToBottom();
 }
 
 void BibleWidget::addToHistory(BibleHistory &b)


### PR DESCRIPTION
1. Allow for space inbetween num_str and name_str (e.g. "1 Peter") during Bible book search. The old way (1Peter) still works. 
2. Scroll to latest history item when new item added.