### PR TITLE
Add F9 shortcut to select Bible Search Field

### DIFF
--- a/biblewidget.cpp
+++ b/biblewidget.cpp
@@ -571,8 +571,14 @@ bool BibleWidget::isVerseSelected()
         return false;
 }
 
-void BibleWidget::setSearchActive()
+void BibleWidget::setBibleBookActive()
 {
     ui->lineEditBook->setFocus();
     ui->lineEditBook->selectAll();
+}
+
+void BibleWidget::setBibleSearchActive()
+{
+    ui->search_ef->setFocus();
+    ui->search_ef->selectAll();
 }

--- a/biblewidget.hpp
+++ b/biblewidget.hpp
@@ -60,7 +60,8 @@ public slots:
     void clearHistory();
     void setSelectedHistory(BibleHistory &b);
     bool isVerseSelected();
-    void setSearchActive();
+    void setBibleBookActive();
+    void setBibleSearchActive();
 
 protected:
     virtual void changeEvent(QEvent *e);

--- a/biblewidget.ui
+++ b/biblewidget.ui
@@ -47,7 +47,7 @@
             </size>
            </property>
            <property name="text">
-            <string>Search:</string>
+            <string>Search (F9):</string>
            </property>
           </widget>
          </item>

--- a/softprojector.cpp
+++ b/softprojector.cpp
@@ -437,7 +437,7 @@ void SoftProjector::keyPressEvent(QKeyEvent *event)
     if(key == Qt::Key_F6)
     {
         ui->projectTab->setCurrentWidget(bibleWidget);
-        bibleWidget->setSearchActive();
+        bibleWidget->setBibleBookActive();
     }
     else if(key == Qt::Key_F7)
     {
@@ -446,6 +446,11 @@ void SoftProjector::keyPressEvent(QKeyEvent *event)
     }
     else if(key == Qt::Key_F8)
         ui->projectTab->setCurrentWidget(announceWidget);
+    if(key == Qt::Key_F9)
+    {
+        ui->projectTab->setCurrentWidget(bibleWidget);
+        bibleWidget->setBibleSearchActive();
+    }
     else if(key == Qt::Key_Left)
         prevSlide();
     else if(key == Qt::Key_Back)


### PR DESCRIPTION
Found it helpful to add a shortcut for the Bible Search field. As far as I can tell, F9 is available so set that as the shortcut key. Also renamed the function called by the F6 shortcut for clarity.