### PR TITLE
Spelling and song widget column width improvements

### DIFF
--- a/biblewidget.ui
+++ b/biblewidget.ui
@@ -127,7 +127,7 @@
          <item>
           <widget class="QPushButton" name="search_button">
            <property name="toolTip">
-            <string>Quickly display  the selected Bible verse on the screen</string>
+            <string>Quickly display the selected Bible verse on the screen</string>
            </property>
            <property name="text">
             <string>Search</string>
@@ -508,7 +508,7 @@ Results</string>
               </sizepolicy>
              </property>
              <property name="toolTip">
-              <string>Quickly display  the selected Bible verse on the screen</string>
+              <string>Quickly display the selected Bible verse on the screen</string>
              </property>
              <property name="text">
               <string>Go Live (F5)</string>

--- a/displayscreen.ui
+++ b/displayscreen.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Dispaly Screen</string>
+   <string>Display Screen</string>
   </property>
   <property name="windowIcon">
    <iconset resource="softprojector.qrc">

--- a/generalsettingwidget.ui
+++ b/generalsettingwidget.ui
@@ -78,7 +78,7 @@
          </sizepolicy>
         </property>
         <property name="toolTip">
-         <string>Select onto which screen to dispaly</string>
+         <string>Select onto which screen to display</string>
         </property>
        </widget>
       </item>
@@ -114,7 +114,7 @@
          </sizepolicy>
         </property>
         <property name="toolTip">
-         <string>Select onto which screen to dispaly</string>
+         <string>Select onto which screen to display</string>
         </property>
        </widget>
       </item>

--- a/projectordisplayscreen.ui
+++ b/projectordisplayscreen.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string>Display Screen</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">

--- a/songwidget.cpp
+++ b/songwidget.cpp
@@ -40,11 +40,12 @@ SongWidget::SongWidget(QWidget *parent) :
 
     // Modify the column widths:
     ui->songs_view->setColumnWidth(0, 0);//Category
-    ui->songs_view->setColumnWidth(1, 40);//Song Number
+    ui->songs_view->setColumnHidden(0, true); // Hide category
+    ui->songs_view->resizeColumnToContents(1); // Song Number
     ui->songs_view->setColumnWidth(2, 150);//Song Title
-    ui->songs_view->setColumnWidth(3, 80);//Songbook
+    ui->songs_view->resizeColumnToContents(3); // Songbook
     ui->songs_view->setColumnWidth(4, 50);//Tune
-
+    
     proxy_model->setSongbookFilter("ALL");
     proxy_model->setCategoryFilter(-1);
     loadSongbooks();

--- a/translations/softpro_cs.ts
+++ b/translations/softpro_cs.ts
@@ -889,7 +889,7 @@ Autorské právo:</translation>
     <message>
         <location filename="../biblewidget.ui" line="130"/>
         <location filename="../biblewidget.ui" line="511"/>
-        <source>Quickly display  the selected Bible verse on the screen</source>
+        <source>Quickly display the selected Bible verse on the screen</source>
         <translation>Rychlé zobrazení vybraného biblického verše na promítací ploše</translation>
     </message>
     <message>
@@ -1150,7 +1150,7 @@ Zkuste změnit hlavní Bibli a otevřete soubor s projektem znovu.</translation>
         <translation type="vanished">Hudba od: %1</translation>
     </message>
     <message>
-        <source>Dispaly Screen</source>
+        <source>Display Screen</source>
         <translation type="vanished">Zobrazovací obrazovka</translation>
     </message>
 </context>
@@ -1925,7 +1925,7 @@ Verš 2
     <message>
         <location filename="../generalsettingwidget.ui" line="81"/>
         <location filename="../generalsettingwidget.ui" line="117"/>
-        <source>Select onto which screen to dispaly</source>
+        <source>Select onto which screen to display</source>
         <translation>Vybrat, na které obrazovce se má zobrazovat</translation>
     </message>
     <message>

--- a/translations/softpro_de.ts
+++ b/translations/softpro_de.ts
@@ -881,7 +881,7 @@ Urheberrecht:</translation>
     <message>
         <location filename="../biblewidget.ui" line="130"/>
         <location filename="../biblewidget.ui" line="511"/>
-        <source>Quickly display  the selected Bible verse on the screen</source>
+        <source>Quickly display the selected Bible verse on the screen</source>
         <translation>Schnelle Anzeige der ausgewählten Bibelverse auf dem Bildschirm</translation>
     </message>
     <message>
@@ -1114,7 +1114,7 @@ results.</source>
 <context>
     <name>DisplayScreen</name>
     <message>
-        <source>Dispaly Screen</source>
+        <source>Display Screen</source>
         <translation type="vanished">Bildschirm</translation>
     </message>
     <message>
@@ -1891,7 +1891,7 @@ Vers 2
     <message>
         <location filename="../generalsettingwidget.ui" line="81"/>
         <location filename="../generalsettingwidget.ui" line="117"/>
-        <source>Select onto which screen to dispaly</source>
+        <source>Select onto which screen to display</source>
         <translation>Wählen Sie, auf welchem Bildschirm angezeigt werden soll</translation>
     </message>
     <message>

--- a/translations/softpro_hy.ts
+++ b/translations/softpro_hy.ts
@@ -477,7 +477,7 @@ Notes:
         <translation>Ներառում արտահայտ</translation>
     </message>
     <message>
-        <source>Quickly display  the selected Bible verse on the screen</source>
+        <source>Quickly display the selected Bible verse on the screen</source>
         <translation>Ցուցադրել ընտրված տեքստը էկրանին</translation>
     </message>
     <message>
@@ -1774,7 +1774,7 @@ Verse-Հատված 2
         <translation>Այս թեման պարունակում է լռելյայն կարքավորումներ.</translation>
     </message>
     <message>
-        <source>Select onto which screen to dispaly</source>
+        <source>Select onto which screen to display</source>
         <translation>Ընտրել ցուցադրման էկրանը</translation>
     </message>
     <message>
@@ -3183,7 +3183,7 @@ We recommend to resize images to display screen size.</source>
         <translation>Տեսամագնիտոֆոնի Սխալ</translation>
     </message>
     <message>
-        <source>Dispaly Screen</source>
+        <source>Display Screen</source>
         <translation>Էկրան</translation>
     </message>
     <message>

--- a/translations/softpro_ru.ts
+++ b/translations/softpro_ru.ts
@@ -486,7 +486,7 @@ Copyright:</source>
         <translation>Содержит фразу</translation>
     </message>
     <message>
-        <source>Quickly display  the selected Bible verse on the screen</source>
+        <source>Quickly display the selected Bible verse on the screen</source>
         <translation>Вывести выбранный текст на экран</translation>
     </message>
     <message>
@@ -605,7 +605,7 @@ Results</source>
         <translation type="vanished">Ошибка видеоплеера</translation>
     </message>
     <message>
-        <source>Dispaly Screen</source>
+        <source>Display Screen</source>
         <translation type="vanished">Экран</translation>
     </message>
     <message>
@@ -1098,7 +1098,7 @@ Verse 2
         <translation>Эта тема содержить установки по умолчанию.</translation>
     </message>
     <message>
-        <source>Select onto which screen to dispaly</source>
+        <source>Select onto which screen to display</source>
         <translation>Выбор экрана для отображения</translation>
     </message>
     <message>

--- a/translations/softpro_ua.ts
+++ b/translations/softpro_ua.ts
@@ -829,7 +829,7 @@ Copyright:</source>
     <message>
         <location filename="../biblewidget.ui" line="130"/>
         <location filename="../biblewidget.ui" line="511"/>
-        <source>Quickly display  the selected Bible verse on the screen</source>
+        <source>Quickly display the selected Bible verse on the screen</source>
         <translation>Вивести текст на екран</translation>
     </message>
     <message>
@@ -1041,7 +1041,7 @@ results.</source>
 <context>
     <name>DisplayScreen</name>
     <message>
-        <source>Dispaly Screen</source>
+        <source>Display Screen</source>
         <translation type="vanished">Екран</translation>
     </message>
     <message>
@@ -1828,7 +1828,7 @@ Verse 2
     <message>
         <location filename="../generalsettingwidget.ui" line="81"/>
         <location filename="../generalsettingwidget.ui" line="117"/>
-        <source>Select onto which screen to dispaly</source>
+        <source>Select onto which screen to display</source>
         <translation>Оберіть екран, на якому буде будуватися зображення</translation>
     </message>
     <message>


### PR DESCRIPTION
1. Renamed "dispaly" to "display", fixing issue #30 
2. Removed extra space in tooltips
3. Hid SongWidget's song category header so that it doesn't appear when double clicking the left side of the song number header
4. Auto-sized SongWidget's song number and songbook hard-coded column widths, so that translated titles can fit