### PR TITLE
Issue 52 media replays after ending and hiding screen

### DIFF
--- a/DisplayArea.qml
+++ b/DisplayArea.qml
@@ -45,6 +45,7 @@ Rectangle {
     signal positionChanged(int position)
     signal durationChanged(int duration)
     signal playbackStateChanged(int state)
+    signal playbackStopped()
 
     MediaPlayer
     {
@@ -64,7 +65,10 @@ Rectangle {
         {
             dispArea.playbackStateChanged(player.playbackState)
         }
-
+        onStopped:
+        {
+            dispArea.playbackStopped()
+        }
     }
 
     VideoOutput

--- a/projectordisplayscreen.cpp
+++ b/projectordisplayscreen.cpp
@@ -302,9 +302,15 @@ void ProjectorDisplayScreen::renderPassiveText(QPixmap &back, bool useBack)
 {
     setTextPixmap(imGen.generateEmptyImage());
     if(useBack)
+    {
+        backType = B_PICTURE;
         setBackPixmap(back,0);
+    }
     else
+    {
+        backType = B_NONE;
         setBackPixmap(imGen.generateColorImage(m_color),0);
+    }
 
     updateScreen();
 }

--- a/projectordisplayscreen.cpp
+++ b/projectordisplayscreen.cpp
@@ -43,6 +43,7 @@ ProjectorDisplayScreen::ProjectorDisplayScreen(QWidget *parent) :
     connect(dispObj,SIGNAL(positionChanged(int)),this,SLOT(videoPositionChanged(int)));
     connect(dispObj,SIGNAL(durationChanged(int)),this,SLOT(videoDurationChanged(int)));
     connect(dispObj,SIGNAL(playbackStateChanged(int)),this,SLOT(videoPlaybackStateChanged(int)));
+    connect(dispObj,SIGNAL(playbackStopped()),this,SLOT(playbackStopped()));
 
     backImSwitch1 = backImSwitch2 = textImSwitch1 = textImSwitch2 = false;
     back1to2 = text1to2 = isNewBack = true;
@@ -467,6 +468,11 @@ void ProjectorDisplayScreen::stopVideo()
 {
     QObject *root = dispView->rootObject();
     QMetaObject::invokeMethod(root,"stopVideo");
+}
+
+void ProjectorDisplayScreen::playbackStopped()
+{
+    emit videoStopped();
 }
 
 void ProjectorDisplayScreen::setVideoVolume(int level)

--- a/projectordisplayscreen.hpp
+++ b/projectordisplayscreen.hpp
@@ -84,6 +84,7 @@ private slots:
     void videoPositionChanged(int position);
     void videoDurationChanged(int duration);
     void videoPlaybackStateChanged(int state);
+    void playbackStopped();
 
 signals:
     void exitSlide();
@@ -93,6 +94,7 @@ signals:
     void videoPositionChanged(qint64 position);
     void videoDurationChanged(qint64 duration);
     void videoPlaybackStateChanged(QMediaPlayer::State state);
+    void videoStopped();
 
 protected:
     void keyReleaseEvent(QKeyEvent *event);

--- a/softprojector.cpp
+++ b/softprojector.cpp
@@ -172,6 +172,7 @@ SoftProjector::SoftProjector(QWidget *parent)
             mediaControls,SLOT(setMaximumTime(qint64)));
     connect(pds1,SIGNAL(videoPlaybackStateChanged(QMediaPlayer::State)),
             mediaControls,SLOT(updatePlayerState(QMediaPlayer::State)));
+    connect(pds1,SIGNAL(videoStopped()),this,SLOT(videoStopped()));
     connect(mediaControls,SIGNAL(play()),this,SLOT(playVideo()));
     connect(mediaControls,SIGNAL(pause()),this,SLOT(pauseVideo()));
     connect(mediaControls,SIGNAL(stop()),this,SLOT(stopVideo()));
@@ -639,6 +640,12 @@ void SoftProjector::setVideoPosition(qint64 position)
     {
         pds2->setVideoPosition(position);
     }
+}
+
+void SoftProjector::videoStopped()
+{
+    showing = false;
+    updateScreen();
 }
 
 void SoftProjector::on_listShow_currentRowChanged(int currentRow)

--- a/softprojector.hpp
+++ b/softprojector.hpp
@@ -189,6 +189,7 @@ private slots:
     void pauseVideo();
     void stopVideo();
     void setVideoPosition(qint64 position);
+    void videoStopped();
 
     void on_listShow_itemSelectionChanged();
     void on_rbMultiVerse_toggled(bool checked);


### PR DESCRIPTION
Prevents video from restarting playback after hiding the screen when it ends, but the last frame still stays on the screen when the video ends if you build with some older versions of Qt. If you build with a newer version of Qt (5.13+), [VideoOutput shows an empty frame after the video stops by default](https://doc.qt.io/qt-5/qml-qtmultimedia-videooutput.html#flushMode-prop), so the problem gets fixed.

Video was restarting in ProjectorDisplayScreen::renderPassiveText() because backType was staying as B_VIDEO when calling updateScreen().